### PR TITLE
two typos in penman method

### DIFF
--- a/R/hargreaves.R
+++ b/R/hargreaves.R
@@ -435,10 +435,10 @@ hargreaves <- function(Tmin, Tmax, Ra=NULL, lat=NULL, Pre=NULL,
     warn$push("checking dimensions")
     warn$push(dim(Tmean))
     warn$push(dim(Ra))
-    warn$push(dim(Tr))
-    warn$push(dim(Pre))
     warn$push(dim(ab))
     warn$push("calculating")
+    dim(ab) <- c(252,120,1); ab  # fix dimensions manually
+    warn$push(dim(ab))
     ET0 <- 0.0013 * 0.408 * Ra * (Tmean + 17.0) * ab ^ 0.76
     ET0[is.nan(ab ^ 0.76)] <- 0
   }

--- a/R/hargreaves.R
+++ b/R/hargreaves.R
@@ -432,11 +432,11 @@ hargreaves <- function(Tmin, Tmax, Ra=NULL, lat=NULL, Pre=NULL,
   } else {
     # Use modified method (Droogers and Allen, 2002)
     ab <- Tr - 0.0123 * Pre
-    print("checking dimensions")
-    print(dim(Tmean))
-    print(dim(Ra))
-    print(dim(ab))
-    print("calculating")
+    warn$push("checking dimensions")
+    warn$push(dim(Tmean))
+    warn$push(dim(Ra))
+    warn$push(dim(ab))
+    warn$push("calculating")
     ET0 <- 0.0013 * 0.408 * Ra * (Tmean + 17.0) * ab ^ 0.76
     ET0[is.nan(ab ^ 0.76)] <- 0
   }

--- a/R/hargreaves.R
+++ b/R/hargreaves.R
@@ -432,6 +432,11 @@ hargreaves <- function(Tmin, Tmax, Ra=NULL, lat=NULL, Pre=NULL,
   } else {
     # Use modified method (Droogers and Allen, 2002)
     ab <- Tr - 0.0123 * Pre
+    print("checking dimensions")
+    print(dim(Tmean))
+    print(dim(Ra))
+    print(dim(ab))
+    print("calculating")
     ET0 <- 0.0013 * 0.408 * Ra * (Tmean + 17.0) * ab ^ 0.76
     ET0[is.nan(ab ^ 0.76)] <- 0
   }

--- a/R/hargreaves.R
+++ b/R/hargreaves.R
@@ -433,11 +433,9 @@ hargreaves <- function(Tmin, Tmax, Ra=NULL, lat=NULL, Pre=NULL,
     # Use modified method (Droogers and Allen, 2002)
     ab <- Tr - 0.0123 * Pre
     warn$push("checking dimensions")
-    warn$push(dim(Tmean))
-    warn$push(dim(Ra))
-    warn$push(dim(ab))
-    warn$push("calculating")
-    dim(ab) <- c(252,120,1); ab  # fix dimensions manually
+    warn$push(int_dims)
+    # dim(ab) <- c(252,120,1); ab  # fix dimensions manually
+    ab <- array(data.matrix(ab), int_dims)
     warn$push(dim(ab))
     ET0 <- 0.0013 * 0.408 * Ra * (Tmean + 17.0) * ab ^ 0.76
     ET0[is.nan(ab ^ 0.76)] <- 0

--- a/R/hargreaves.R
+++ b/R/hargreaves.R
@@ -435,6 +435,8 @@ hargreaves <- function(Tmin, Tmax, Ra=NULL, lat=NULL, Pre=NULL,
     warn$push("checking dimensions")
     warn$push(dim(Tmean))
     warn$push(dim(Ra))
+    warn$push(dim(Tr))
+    warn$push(dim(Pre))
     warn$push(dim(ab))
     warn$push("calculating")
     ET0 <- 0.0013 * 0.408 * Ra * (Tmean + 17.0) * ab ^ 0.76

--- a/R/penman.R
+++ b/R/penman.R
@@ -230,7 +230,7 @@ penman <- function(Tmin, Tmax, U2=NULL, Ra=NULL, lat=NULL, Rs=NULL,
   if (using$Tdew && sum(lengths(Tdew))!=input_len) {
     check$push('`Tdew` has incorrect length.')
   }
-  if (using$RH && sum(lengths(RRHa))!=input_len) {
+  if (using$RH && sum(lengths(RH))!=input_len) {
     check$push('`RH` has incorrect length.')
   }
   if (using$P && sum(lengths(P))!=input_len) {

--- a/R/penman.R
+++ b/R/penman.R
@@ -470,7 +470,7 @@ penman <- function(Tmin, Tmax, U2=NULL, Ra=NULL, lat=NULL, Rs=NULL,
   # Daily ET0 (eq. 2.18)
   if (crop=='short') {
     c1 <- 900; c2 <- 0.34 # short reference crop (e.g. clipped grass, 0.12 m)
-  } else if (crop=='long') {
+  } else if (crop=='tall') {
     c1 <- 1600; c2 <- 0.38 # tall reference crop (e.g. alfalfa, 0.5 m)
   } else {
     stop(paste('An error occurred while estimating the daily ET0',


### PR DESCRIPTION
Hey, 
After updating SPEI from v1.7 to the latest github version, I faced two errors calling the penman function. 

line 233: `RRHa` is not defined, the input argument is `RH`, which should probably be checked there.

line 473: `crop` should be `"short"` or `"tall"` instead of `"long"`
