### PR TITLE
Fix issue in hargreaves function

### DIFF
--- a/R/hargreaves.R
+++ b/R/hargreaves.R
@@ -490,7 +490,7 @@ hargreaves <- function(Tmin, Tmax, Ra = NULL, lat = NULL, Pre = NULL,
     ET0 <- 0.0023 * 0.408 * Ra * (Tmean + 17.8) * Tr^0.5
   } else {
     # Use modified method (Droogers and Allen, 2002)
-    ab <- Tr - 0.0123 * Pre
+    ab <- Tr - 0.0123 * Rs
     ET0 <- 0.0013 * 0.408 * Ra * (Tmean + 17.0) * ab^0.76
     ET0[is.nan(ab^0.76)] <- 0
   }


### PR DESCRIPTION
The following code
```R
# Load data for Tampa, lat=37.6475N, elevation=402.6 m. a.s.l.
# Data consists on monthly values since January 1980
data(wichita)
attach(wichita)
names(wichita)

# Matrix input (data from several stations)
# Replicating Wichita data twice to simulate data at two locations.
tmin <- cbind(TMIN, TMIN + 1.5)
tmax <- cbind(TMAX, TMAX + 1.5)
tmin <- ts(tmin, start=c(2000, 1), frequency = 12)
tmax <- ts(tmax, start=c(2000, 1), frequency = 12)
precip <- ts(matrix(runif(prod(dim(tmax)), min=0, max=23), ncol=2), start=c(2000, 1), frequency = 12)
lat <- c(37.6475, 35.000)
har <- hargreaves(tmin, tmax, lat = lat, Pre=precip, na.rm = TRUE)
```
give this error:
```
Error in `*.default`(0.0013 * 0.408 * Ra * (Tmean + 17), ab^0.76) :
non-conformable arrays
```
I fixed it by replacing `Pre` with `Rs` (see diff) 
`Rs` is created inside the function with conformable array dimenstions